### PR TITLE
Current version and documentation mismatch fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ repositories {
 }
 
 dependencies {
-    api("com.target:lite-for-jdbc:1.8.1")
+    api("com.target:lite-for-jdbc:2.1.0")
 }
 ```
 
 # Db Setup
 
 The core of lite-for-jdbc is the Db class. A Db object is intended to be used as a singleton and
-injected as a dependency in repository classes. It requires a DataSource constructor argument,
+injected as a dependency in repository classes. It requires a DataSource constructor argument,  
 and there is a DataSourceFactory to help with that.
 The typical recommendation is to use Hikari, which is configured with reasonable defaults, but you can customize
 it to any DataSource.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ repositories {
 }
 
 dependencies {
-    api("com.target:lite-for-jdbc:2.1.0")
+    api("com.target:lite-for-jdbc:2.1.1")
 }
 ```
 


### PR DESCRIPTION
* Updated documented version to current 2.1.0 from 1.8.1 as the breaking changes to DataSourceFactory make the documentation incorrect