### PR TITLE
 Minor performance/memory tweak by removing unnecessary duplication

### DIFF
--- a/src/main/kotlin/com/target/liteforjdbc/ConnectionSession.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/ConnectionSession.kt
@@ -233,7 +233,7 @@ sealed class ConnectionSession(
         while (resultSet.next()) {
             result.add(rowMapper.invoke(resultSet))
         }
-        return result.toList()
+        return result
     }
 
     private fun <T> callInternalPositionalParams(sql: String, action: (pstmt: PreparedStatement) -> T, vararg args: Any?): T =


### PR DESCRIPTION
Reason for change: To remove the redundant list creation as this is a "low level function" and there is no need to incur the GC penalty.

Calling 'toList()' on a mutable list creates another unnecessary shallow mutable copy of a list, as Kotlin doesn't actually implement immutable lists. Immutability in Kotlin is only supported by interface, not by implementation (unless the initial list is of zero length [static emptyList], or 1 which is a SingletonList).

The implementation of 'toList()' is simply implemented as (kotlin.collections._Collections):

```
public fun <T> Iterable<T>.toList(): List<T> {
    if (this is Collection) {
        return when (size) {
            0 -> emptyList()
            1 -> listOf(if (this is List) get(0) else iterator().next())
            else -> this.toMutableList()
        }
    }
    return this.toMutableList().optimizeReadOnlyList()
}

// Which, in case of a Collection (our List) will most likely invoke:

/**
 * Returns a new [MutableList] filled with all elements of this collection.
 */
public fun <T> Collection<T>.toMutableList(): MutableList<T> {
    return ArrayList(this)
}
```