### PR TITLE
Adding experimental function 'mapRow'

### DIFF
--- a/src/main/kotlin/com/target/liteforjdbc/ext/ResultSetMapper.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/ext/ResultSetMapper.kt
@@ -1,0 +1,207 @@
+package com.target.liteforjdbc.ext
+
+import java.sql.ResultSet
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.primaryConstructor
+import mu.KotlinLogging
+
+typealias Transform = (Any?) -> Any?
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Applying this function to a [ResultSet] will attempt to instantiate [R] by matching column names within [rs],
+ * converting column names (snake case assumed) to their equivalent kotlin constructor property names
+ * (camel case assumed).
+ *
+ * __Example usage__
+ *
+ * Consider simple table structure such as:
+ *
+ * ```
+ * create table if not exists users
+ * (
+ *     id         serial primary key,
+ *     created_at timestamp with time zone default CURRENT_TIMESTAMP,
+ *     username   varchar(30) not null,
+ *     info       varchar(400),
+ *     email      varchar(40),
+ *     phone      varchar(40),
+ *     status     varchar(15)
+ * )
+ * ```
+ * Our simple User class:
+ * ```
+ * data class User(
+ *   val id: Int,
+ *   val createdAt: Instant,
+ *   val username: String,
+ *   val info: String?,
+ *   val phone: String?,
+ *   val email: String?,
+ *   val status: String?
+ * )
+ * *  ```
+ *
+ * In this example, the simplest use case could be reduced to simply supplying a reference to this [mapRow]
+ * function to the `rowMapper` property (within the `lite-for-jdbc` library).
+ *
+ * ```
+ * fun findAllUsers(): List<User> = db.findAll(sql = "select * from users", rowMapper = ::mapRow)
+ * ```
+ *
+ * Creating a val to use as a mapper (all options being utilized for informational purposes, not required):
+ * ```
+ * private val rowMapper: RowMapper<User> = { mapRow(
+ *            rs = it,
+ *            valueFor = mapOf("phone" to "xxx-xxx-xxxx"),
+ *            transform = mapOf("username" to { x -> (x as? String)?.lowercase() }),
+ *            skip = setOf("status"),
+ *            remap = mapOf("someProperty" to "some_column_name")
+ *        )
+ *  }
+ *
+ * fun findAllUsers(): List<User> = db.findAll(sql = "select * from users", rowMapper = mapper)
+ *
+ *```
+ *
+ * Declaring the function inline:
+ * ```
+ * fun findAllUsers(): List<User> = db.findAll(
+ *      sql = "select * from users",
+ *      rowMapper = { mapRow(
+ *          rs = it,
+ *          valueFor = mapOf("phone" to "xxx-xxx-xxxx"),
+ *          transform = mapOf("username" to { x -> (x as? String)?.lowercase() }),
+ *          skip = setOf("status"),
+ *          remap = mapOf("someProperty" to "some_column_name")
+ *       )
+ *  )
+ * ```
+ *
+ * The simplest case in this form is (again, could be reduced to ::mapRow):
+ *
+ * ```
+ * fun findAllUsers(): List<User> = db.findAll(
+ *      sql = "select * from users",
+ *      rowMapper = { mapRow(it) }
+ *  )
+ * ```
+ *
+ * Simply applying the [mapRow] function to a result set (as this function is not tied to
+ * lite-for-jdbc):
+ *
+ * ```
+ * val user: User = mapRow(resultSet)
+ * ```
+ *
+ * Or manually mapping over a result set:
+ * ```
+ * fun users(rs: ResultSet): List<User> = mutableListOf<Example>().apply {
+ *       while(rs.next()) {
+ *         add(mapRow(rs))
+ *       }
+ *     }
+ * ```
+ *
+ * @param rs a result set
+ *
+ * @param remap a mapping of a kotlin class' constructor argument and pairs that with a column which doesn't by
+ *         default match the property by a simple "snake to camel case" conversion.
+ *
+ * @param valueFor a mapping of a class' constructor arg to a default value. This is useful for when a result set
+ *         does not contain a value for the argument and/or if the constructor argument does not have a default value,
+ *         or if the default value is not appropriate for the use case
+ *
+ * @param skip a set of property names which informs the mapper to simply skip the given property and not attempt to bind
+ *        that value from the result set This is close to the [valueFor] argument, but requires no value (there
+ *        must be a default value set in the constructor)
+ *
+ * @param transform a mapping of an incoming property name (using the kotlin property, not column name), which will apply
+ *        the transformation function and bind this value to the constructor argument
+ *
+ * @return [R] the expected output type
+ */
+inline fun <reified R : Any> mapRow(
+  rs: ResultSet,
+  remap: Map<String, String> = emptyMap(),
+  valueFor: Map<String, Any> = emptyMap(),
+  skip: Set<String> = emptySet(),
+  transform: Map<String, (Any?) -> Any?> = emptyMap()
+): R {
+  val constructor = R::class.primaryConstructor
+    ?: error("No primary constructor found on <${R::class}>, is this a class?")
+
+  return rs.mapRow(
+    constructor = constructor,
+    valueFor = valueFor,
+    remap = remap,
+    skip = skip,
+    transform = transform
+  )
+}
+
+val identity = { value: Any? -> value }
+
+// This was extracted from `mapRow` as we only need the inline function [mapRow] for the reified ability,
+// and this will reduce amount of inlined code
+fun <R : Any?> ResultSet.mapRow(
+  constructor: KFunction<R>,
+  valueFor: Map<String, Any>,
+  remap: Map<String, String>,
+  skip: Set<String>,
+  transform: Map<String, (Any?) -> Any?>
+): R {
+  val columnMapping = metaData.let { metadata ->
+    (1..metadata.columnCount).associate {
+      metadata.getColumnName(it) to metadata.getColumnType(it)
+    }
+  }
+
+  return constructor.parameters
+    .associateWith { parameter ->
+      val name = parameter.name ?: error("Parameter `$parameter` does not have a name.")
+      when {
+        skip.contains(name) -> Unit // unit is not a valid value and will be filtered out
+        valueFor.contains(name) -> valueFor[name]
+        else -> {
+          remap.getOrDefault(name, name).let {
+            val columnName = it.camelToSnakeCase()
+            val sqlType = columnMapping[columnName]
+            if (sqlType == null) {
+              log.debug {
+                """No column matches entry for: `$columnName`.
+                | The column's value will simply be ignored and removed from the parameter list when invoking the 
+                | the constructor. If the constructor does not have a default argument, then instantiation will fail.
+                |Consider:
+                |- Using an alias for the column to match the property (snake case form)
+                |- Provide a default value within the `valueFor` using the class' constructor parameter name `$it`
+                |- Use `remap` to provide a different property to match the column name
+                |- Use `skip` to ignore the binding attempt altogether for this property
+                |- Do not query for the value to simply ignore it
+                |""".trimMargin()
+              }
+              // Unit is returned which will be filtered out.
+            } else {
+              transform.getOrDefault(name, identity)(readValue(sqlType, columnName))
+            }
+          }
+        }
+      }
+    }
+    .filter { (_, v) -> v != Unit } // Unit is not a valid value meaning one wasn't supplied.
+    .also {
+      log.debug {
+        "Parameter bindings to be applied to $constructor are: $it"
+      }
+    }
+    .runCatching(constructor::callBy)
+    .onFailure { ex ->
+      log.error(ex) {
+        """Unable to invoke constructor for $constructor. Message: ${ex.message}. 
+          |Hint: Check the expected types in the constructor match the inputs given to invoke
+          |Constructor parameters are: ${constructor.parameters.map { it.name }}""".trimMargin()
+      }
+    }
+    .getOrThrow()
+}

--- a/src/main/kotlin/com/target/liteforjdbc/ext/SqlType.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/ext/SqlType.kt
@@ -1,0 +1,95 @@
+package com.target.liteforjdbc.ext
+
+import java.sql.Types
+
+/**
+ * A Kotlin enum which simply wraps the [java.sql.Types] to make resolving and
+ * compiler enforcement of values possible. [java.sql.Types] predates enums in Java, and
+ * are difficult to follow as they are simply Int constants.
+ */
+enum class SqlType(val type: Int) {
+  BIT(Types.BIT),
+  BOOLEAN(Types.BIT),
+  TINYINT(Types.TINYINT),
+  SMALLINT(Types.TINYINT),
+  INTEGER(Types.INTEGER),
+  BIGINT(Types.BIGINT),
+  REAL(Types.REAL),
+  FLOAT(Types.FLOAT),
+  DOUBLE(Types.DOUBLE),
+  NUMERIC(Types.NUMERIC),
+  DECIMAL(Types.DECIMAL),
+  CHAR(Types.CHAR),
+  VARCHAR(Types.VARCHAR),
+  LONGVARCHAR(Types.LONGVARCHAR),
+  DATE(Types.DATE),
+  TIME(Types.TIME),
+  TIMESTAMP(Types.TIMESTAMP),
+  TIMESTAMP_WITH_TIMEZONE(Types.TIMESTAMP_WITH_TIMEZONE),
+  BINARY(Types.BINARY),
+  VARBINARY(Types.VARBINARY),
+  LONGVARBINARY(Types.LONGVARBINARY),
+  NULL(Types.NULL),
+  JAVA_OBJECT(Types.JAVA_OBJECT),
+  DISTINCT(Types.DISTINCT),
+  OTHER(Types.OTHER),
+  STRUCT(Types.STRUCT),
+  ARRAY(Types.ARRAY),
+  BLOB(Types.BLOB),
+  CLOB(Types.CLOB),
+  REF(Types.REF),
+  DATALINK(Types.DATALINK),
+  ROWID(Types.ROWID),
+  NCHAR(Types.NCHAR),
+  NVARCHAR(Types.NVARCHAR),
+  LONGNVARCHAR(Types.LONGNVARCHAR),
+  NCLOB(Types.NCLOB),
+  SQLXML(Types.SQLXML),
+  REF_CURSOR(Types.REF_CURSOR),
+  TIME_WITH_TIMEZONE(Types.TIME_WITH_TIMEZONE);
+
+  companion object {
+    fun typeOf(int: Int) = when (int) {
+      Types.BIT -> BIT
+      Types.BOOLEAN -> BOOLEAN
+      Types.TINYINT -> TINYINT
+      Types.SMALLINT -> SMALLINT
+      Types.BIGINT -> BIGINT
+      Types.INTEGER -> INTEGER
+      Types.REAL -> REAL
+      Types.FLOAT -> FLOAT
+      Types.DOUBLE -> DOUBLE
+      Types.NUMERIC -> NUMERIC
+      Types.DECIMAL -> DECIMAL
+      Types.CHAR -> CHAR
+      Types.VARCHAR -> VARCHAR
+      Types.LONGVARCHAR -> LONGVARCHAR
+      Types.DATE -> DATE
+      Types.TIME -> TIME
+      Types.TIMESTAMP -> TIMESTAMP
+      Types.TIMESTAMP_WITH_TIMEZONE -> TIMESTAMP_WITH_TIMEZONE
+      Types.BINARY -> BINARY
+      Types.VARBINARY -> VARBINARY
+      Types.LONGVARBINARY -> LONGVARBINARY
+      Types.NULL -> NULL
+      Types.JAVA_OBJECT -> JAVA_OBJECT
+      Types.DISTINCT -> DISTINCT
+      Types.OTHER -> OTHER
+      Types.STRUCT -> STRUCT
+      Types.ARRAY -> ARRAY
+      Types.BLOB -> BLOB
+      Types.CLOB -> CLOB
+      Types.REF -> REF
+      Types.DATALINK -> DATALINK
+      Types.ROWID -> ROWID
+      Types.NCHAR -> NCHAR
+      Types.NVARCHAR -> NVARCHAR
+      Types.LONGNVARCHAR -> LONGNVARCHAR
+      Types.NCLOB -> NCLOB
+      Types.SQLXML -> SQLXML
+      Types.REF_CURSOR -> REF_CURSOR
+      Types.TIME_WITH_TIMEZONE -> TIME_WITH_TIMEZONE
+      else -> throw IllegalArgumentException("Unknown type: $int found in java.sql.Types.")
+    }
+  }
+}

--- a/src/main/kotlin/com/target/liteforjdbc/ext/_ResultSet.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/ext/_ResultSet.kt
@@ -1,0 +1,47 @@
+package com.target.liteforjdbc.ext
+
+import java.lang.UnsupportedOperationException
+import java.sql.ResultSet
+
+/**
+ * Reads a value from a given column name and invokes the `get***` from the result to match the
+ * input type.
+ *
+ * Time and Timestamps will be returned as [java.time.Instant] instances.
+ *
+ * Note, the following types are not supported:
+ *  - STRUCT
+ *  - DATALINK
+ *  - REF_CURSOR
+ *  - ROW_ID
+ *
+ *  @throws UnsupportedOperationException if any of the unsupported types are requested.
+ */
+fun ResultSet.readValue(type: Int, column: String): Any? = when (SqlType.typeOf(type)) {
+  SqlType.BIT, SqlType.BOOLEAN ->  getBoolean(column)
+  SqlType.TINYINT, SqlType.SMALLINT, SqlType.INTEGER -> getInt(column)
+  SqlType.BIGINT -> getLong(column)
+  SqlType.REAL ->  getFloat(column)
+  SqlType.FLOAT, SqlType.DOUBLE -> getDouble(column)
+  SqlType.NUMERIC, SqlType.DECIMAL -> getBigDecimal(column)
+  SqlType.CHAR, SqlType.VARCHAR, SqlType.LONGVARCHAR -> getString(column)
+  SqlType.DATE -> getDate(column)
+  SqlType.TIME -> getTime(column).toInstant()
+  SqlType.TIMESTAMP ->  getTimestamp(column).toInstant()
+  SqlType.TIMESTAMP_WITH_TIMEZONE -> getTimestamp(column).toInstant()
+  SqlType.BINARY, SqlType.VARBINARY, SqlType.LONGVARBINARY ->  getBytes(column)
+  SqlType.NULL -> null
+  SqlType.JAVA_OBJECT, SqlType.DISTINCT, SqlType.OTHER -> getObject(column)
+  SqlType.STRUCT -> throw UnsupportedOperationException("java.sql.Types.STRUCT is currently unsupported.")
+  SqlType.ARRAY -> getArray(column)
+  SqlType.BLOB -> getBlob(column)
+  SqlType.CLOB -> getString(column)
+  SqlType.REF -> getRef(column)
+  SqlType.DATALINK -> throw UnsupportedOperationException("java.sql.Types.DATALINK is currently unsupported.")
+  SqlType.ROWID -> throw UnsupportedOperationException("java.sql.Types.ROWID is currently unsupported.")
+  SqlType.NCHAR, SqlType.NVARCHAR, SqlType.LONGNVARCHAR -> getNString(column)
+  SqlType.NCLOB -> getNClob(column)
+  SqlType.SQLXML -> getSQLXML(column)
+  SqlType.REF_CURSOR -> throw UnsupportedOperationException("java.sql.Types.REF_CURSOR is currently unsupported.")
+  SqlType.TIME_WITH_TIMEZONE -> getTime(column).toInstant()
+}

--- a/src/main/kotlin/com/target/liteforjdbc/ext/_String.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/ext/_String.kt
@@ -1,0 +1,3 @@
+package com.target.liteforjdbc.ext
+
+fun String.camelToSnakeCase(): String = com.target.liteforjdbc.camelToSnakeCase(this)

--- a/src/test/kotlin/com/target/liteforjdbc/ext/ResultSetMapperTest.kt
+++ b/src/test/kotlin/com/target/liteforjdbc/ext/ResultSetMapperTest.kt
@@ -1,0 +1,194 @@
+package com.target.liteforjdbc.ext
+
+import com.target.liteforjdbc.RowMapper
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import java.sql.ResultSet
+import java.sql.ResultSetMetaData
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ResultSetMapperTest {
+
+  @MockK(relaxed = true)
+  lateinit var mockExampleResultSet1: ResultSet
+
+  @MockK(relaxed = true)
+  lateinit var mockExampleResultSet2: ResultSet
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this)
+
+    every { mockExampleResultSet1.getInt("id") }.answers { 42 }
+    every { mockExampleResultSet1.getString("name") }.answers { "Target" }
+    every { mockExampleResultSet1.getTimestamp("instant") }.answers { Timestamp(0) }
+    every { mockExampleResultSet1.getBoolean("enabled") }.answers { true }
+    every { mockExampleResultSet1.getObject("global_id") }.answers { UUID.fromString("4ad9d3c5-e868-4f19-9a7a-6fced128d230") }
+    every { mockExampleResultSet1.getString("ldap_name") }.answers { "TargetUser" }
+    every { mockExampleResultSet1.getString("status") }.answers { "Offline" }
+    every { mockExampleResultSet1.getString("no_default_mapping") }.answers { "I need remapping" }
+
+    every { mockExampleResultSet2.getInt("id") }.answers { 23 }
+    every { mockExampleResultSet2.getString("name") }.answers { "NotTarget" }
+    every { mockExampleResultSet2.getTimestamp("instant") }.answers { Timestamp(1677593073027) }
+    every { mockExampleResultSet2.getBoolean("enabled") }.answers { false }
+    every { mockExampleResultSet2.getObject("global_id") }.answers { UUID.fromString("5ad9d3c5-e868-4f19-9a7a-6fced128d230") }
+    every { mockExampleResultSet2.getString("ldap_name") }.answers { "NotTargetUser" }
+    every { mockExampleResultSet2.getString("status") }.answers { "Online" }
+    every { mockExampleResultSet2.getString("no_default_mapping") }.answers { "I have been remapped if you can read this" }
+
+    every { mockExampleResultSet1.metaData }.answers { MockSuperSimpleMetaData }
+    every { mockExampleResultSet2.metaData }.answers { MockSuperSimpleMetaData }
+  }
+
+  @Test
+  fun `All values have been bound from result set`() {
+    val statusTransformer: Transform = { x -> Status.valueOf(x.toString()) }
+    val result: Example = mapRow(mockExampleResultSet2,
+      transform = mapOf("status" to statusTransformer),
+      remap = mapOf("remapMe" to "no_default_mapping")
+    )
+    val expected = Example(
+      id=23, name = "NotTarget",
+      instant = Timestamp(1677593073027).toInstant(),
+      enabled = false,
+      ldapName = "NotTargetUser",
+      globalId = UUID.fromString("5ad9d3c5-e868-4f19-9a7a-6fced128d230"),
+      status = Status.Online,
+      remapMe = "I have been remapped if you can read this"
+    )
+
+    assertEquals(expected, result)
+  }
+
+  @Test
+  fun `Option 'skip' ignores value`() {
+    val simple: Example = mapRow(mockExampleResultSet1, skip = setOf("status"))
+    assertEquals(Example(), simple)
+  }
+
+  @Test
+  fun `Option 'transform' supplies new value`() {
+    val statusTransformer: Transform = { x -> Status.valueOf(x.toString()) }
+
+    val rowMapper: RowMapper<Example> = { rs ->
+      mapRow(
+        rs = rs,
+        transform = mapOf("status" to statusTransformer)
+      )
+    }
+
+    val simple = rowMapper(mockExampleResultSet1)
+
+    assertEquals(Example(), simple)
+  }
+
+
+  @Test
+  fun `Option 'valueFor' supplies value`() {
+    val simple: Example = mapRow(
+      rs = mockExampleResultSet1,
+      valueFor = mapOf("name" to "Target Warehouse"),
+      skip = setOf("status")
+    )
+    assertEquals(Example(name = "Target Warehouse"), simple)
+  }
+
+
+  @Test
+  fun `Option 'remap' applies alternate value value`() {
+    val simple: Example = mapRow(
+      rs = mockExampleResultSet1,
+      skip = setOf("status"),
+      remap = mapOf("remapMe" to "no_default_mapping")
+    )
+    assertEquals(Example(remapMe = "I need remapping"), simple)
+  }
+
+
+  @Test
+  fun `All options used`() {
+    val simple: Example = mapRow(
+      rs = mockExampleResultSet1,
+      valueFor = mapOf("phone" to "xxx-xxx-xxxx"),
+      transform = mapOf("username" to { x -> (x as? String)?.lowercase() }),
+      skip = setOf("status"),
+      remap = mapOf("someProperty" to "some_column_name")
+    )
+    assertEquals(Example(remapMe = "I need remapping"), simple)
+  }
+}
+
+data class Example(
+  val id: Int = 42,
+  val name: String = "Target",
+  val instant: Instant = Timestamp(0).toInstant(),
+  val enabled: Boolean = true,
+  val ldapName: String = "TargetUser",
+  val globalId: UUID = UUID.fromString("4ad9d3c5-e868-4f19-9a7a-6fced128d230"),
+  val status: Status = Status.Offline,
+  val remapMe: String = "I need remapping"
+)
+
+enum class Status {
+  Online,
+  Offline
+}
+
+private object MockSuperSimpleMetaData : MockResultSetMetaData() {
+  override fun getColumnName(column: Int): String = when (column) {
+    1 -> "id"
+    2 -> "name"
+    3 -> "instant"
+    4 -> "enabled"
+    5 -> "global_id"
+    6 -> "ldap_name"
+    7 -> "status"
+    8 -> "no_default_mapping"
+    else -> error("Column $column not mapped for test case")
+  }
+
+  override fun getColumnType(column: Int): Int = when (column) {
+    1 -> SqlType.INTEGER.type
+    2, 6, 7, 8 -> SqlType.VARCHAR.type
+    3 -> SqlType.TIMESTAMP_WITH_TIMEZONE.type
+    4 -> SqlType.BOOLEAN.type
+    5 -> SqlType.JAVA_OBJECT.type
+    else -> error("Column $column not mapped for test case")
+  }
+
+  override fun getColumnCount(): Int = 8
+}
+
+private open class MockResultSetMetaData : ResultSetMetaData {
+  override fun <T : Any?> unwrap(iface: Class<T>?): T = TODO("Not implemented")
+  override fun isWrapperFor(iface: Class<*>?): Boolean = TODO("Not implemented")
+  override fun getColumnCount(): Int = TODO("Not implemented")
+  override fun isAutoIncrement(column: Int): Boolean = TODO("Not implemented")
+  override fun isCaseSensitive(column: Int): Boolean = TODO("Not implemented")
+  override fun isSearchable(column: Int): Boolean = TODO("Not implemented")
+  override fun isCurrency(column: Int): Boolean = TODO("Not implemented")
+  override fun isNullable(column: Int): Int = TODO("Not implemented")
+  override fun isSigned(column: Int): Boolean = TODO("Not implemented")
+  override fun getColumnDisplaySize(column: Int): Int = TODO("Not implemented")
+  override fun getColumnLabel(column: Int): String = TODO("Not implemented")
+  override fun getColumnName(column: Int): String = TODO("Not implemented")
+  override fun getSchemaName(column: Int): String = TODO("Not implemented")
+  override fun getPrecision(column: Int): Int = TODO("Not implemented")
+  override fun getScale(column: Int): Int = TODO("Not implemented")
+  override fun getTableName(column: Int): String = TODO("Not implemented")
+  override fun getCatalogName(column: Int): String = TODO("Not implemented")
+  override fun getColumnType(column: Int): Int = TODO("Not implemented")
+  override fun getColumnTypeName(column: Int): String = TODO("Not implemented")
+  override fun isReadOnly(column: Int): Boolean = TODO("Not implemented")
+  override fun isWritable(column: Int): Boolean = TODO("Not implemented")
+  override fun isDefinitelyWritable(column: Int): Boolean = TODO("Not implemented")
+  override fun getColumnClassName(column: Int): String = TODO("Not implemented")
+}
+


### PR DESCRIPTION
Added 'mapRow' (found in ResultSetMapper.kt) and its supporting enums, functions.

I wanted to start a conversation about whether or not something like this could be useful, as I have already been using it a bit in my endeavors using lite-for-jdbc.

This 'mapRow' function reduces the boilerplate of manual mapping code required and allows for a quick turnaround for simpler use cases when result sets closely match their expected return Kotlin types. Please see the initial Kdoc on the function, as well as the unit tests (ResultSetMapperTest.kt).

I believe this is still inline with the heart/goal of lite-for-jdbc as this does not perform any sql generation magic.

As stated this is experimental as some liberties are being made on Timestamps whereas this mapping tool currently will convert all Timestamp and Time values to java.time.Instant as Timestamp is not an appropriate type to pass around outside of the relational/SQL boundary. There may be an issue with the Calendar on Timestamp, see the extension function `readValue` in _ResultSet.kt