### PR TITLE
Add TargetServerType for building connection with failover support.

### DIFF
--- a/src/main/kotlin/com/target/liteforjdbc/DbConfig.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/DbConfig.kt
@@ -6,6 +6,36 @@ object DbType {
     const val H2_FILE = "H2_FILE"
 }
 
+/**
+ * @see <a href="https://jdbc.postgresql.org/documentation/use/">Postgres JDBC documentation</a>.
+ */
+enum class TargetServerType(val jdbcParameterValue: String) {
+    /*
+     * Any host in the list of hosts.
+     */
+    ANY("any"),
+
+    /*
+     * Connect to the host allowing writes.
+     */
+    PRIMARY("primary"),
+
+    /*
+     * Attempt to connect to primary. Fallback to secondary if primary is not available.
+     */
+    PREFER_PRIMARY("preferPrimary"),
+
+    /*
+     * Connect to the host accepting writes.
+     */
+    SECONDARY("secondary"),
+
+    /*
+     * Attempt to connect to secondary. Fallback to primary if secondary is not available.
+     */
+    PREFER_SECONDARY("preferSecondary")
+}
+
 data class DbConfig(
     val type: String = DbType.POSTGRES,
     val host: String = System.getenv(DATABASE_HOST_ENV_NAME) ?: "127.0.0.1",
@@ -21,4 +51,5 @@ data class DbConfig(
     val maxLifetime: Long = 300_000,
     val minimumIdle: Int = 1,
     val maximumPoolSize: Int = 5,
+    val targetServerType: TargetServerType = TargetServerType.ANY
 )

--- a/src/main/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilder.kt
+++ b/src/main/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilder.kt
@@ -21,5 +21,7 @@ fun buildPostgresDataSource(config: DbConfig): HikariDataSource {
         dataSource.addDataSourceProperty("sslmode", "require")
     }
 
+    dataSource.addDataSourceProperty("targetServerType", config.targetServerType.jdbcParameterValue)
+
     return dataSource
 }

--- a/src/test/kotlin/com/target/liteforjdbc/DbConfigTest.kt
+++ b/src/test/kotlin/com/target/liteforjdbc/DbConfigTest.kt
@@ -7,6 +7,18 @@ import org.junit.jupiter.api.Test
 class DbConfigTest {
 
     @Test
+    fun `Test TargetServerType jdbc parameter values`() {
+        TargetServerType.ANY.jdbcParameterValue shouldBe "any"
+
+        TargetServerType.PRIMARY.jdbcParameterValue shouldBe "primary"
+        TargetServerType.PREFER_PRIMARY.jdbcParameterValue shouldBe "preferPrimary"
+
+        TargetServerType.SECONDARY.jdbcParameterValue shouldBe "secondary"
+        TargetServerType.PREFER_SECONDARY.jdbcParameterValue shouldBe "preferSecondary"
+    }
+
+
+    @Test
     fun `Test Environment host`() {
         val expectedHost = "expectedHost"
         val config = withEnvironment(DATABASE_HOST_ENV_NAME, expectedHost) {

--- a/src/test/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilderTest.kt
+++ b/src/test/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilderTest.kt
@@ -2,10 +2,13 @@ package com.target.liteforjdbc.postgres
 
 import com.target.liteforjdbc.DbConfig
 import com.target.liteforjdbc.DbType
+import com.target.liteforjdbc.TargetServerType
 import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 
 class PostgresDataSourceBuilderTest {
@@ -73,7 +76,7 @@ class PostgresDataSourceBuilderTest {
             keepAliveTime = 3000,
             maxLifetime = 4000,
             minimumIdle = 1,
-            maximumPoolSize = 10
+            maximumPoolSize = 10,
         )
 
         val result = buildPostgresDataSource(config)
@@ -110,6 +113,44 @@ class PostgresDataSourceBuilderTest {
             maxLifetime = 4000,
             minimumIdle = 1,
             maximumPoolSize = 10
+        )
+
+        val result = buildPostgresDataSource(config)
+
+        result.jdbcUrl shouldBe "jdbc:postgresql://host:1234/dbName"
+        result.connectionTimeout shouldBe 1000
+        result.idleTimeout shouldBe 2000
+        result.keepaliveTime shouldBe 3000
+        result.maxLifetime shouldBe 4000
+        result.minimumIdle shouldBe 1
+        result.maximumPoolSize shouldBe 10
+        result.dataSourceProperties["reWriteBatchedInserts"] shouldBe "true"
+
+        result.dataSourceProperties.keys shouldNotContain "ssl"
+        result.dataSourceProperties.keys shouldNotContain "sslfactory"
+        result.dataSourceProperties.keys shouldNotContain "sslmode"
+
+        result.username shouldBe "user"
+        result.password shouldBe "password"
+    }
+
+    @ParameterizedTest
+    @EnumSource(TargetServerType::class)
+    fun `Test targetServerTypes`(targetServerType: TargetServerType) {
+        val config = DbConfig(
+            databaseName = "dbName",
+            host = "host",
+            port = 1234,
+            username = "user",
+            password = "password",
+            ssl = false,
+            connectionTimeoutMillis = 1000,
+            idleTimeoutMillis = 2000,
+            keepAliveTime = 3000,
+            maxLifetime = 4000,
+            minimumIdle = 1,
+            maximumPoolSize = 10,
+            targetServerType = targetServerType
         )
 
         val result = buildPostgresDataSource(config)

--- a/src/test/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilderTest.kt
+++ b/src/test/kotlin/com/target/liteforjdbc/postgres/PostgresDataSourceBuilderTest.kt
@@ -139,37 +139,15 @@ class PostgresDataSourceBuilderTest {
     fun `Test targetServerTypes`(targetServerType: TargetServerType) {
         val config = DbConfig(
             databaseName = "dbName",
-            host = "host",
-            port = 1234,
             username = "user",
             password = "password",
-            ssl = false,
-            connectionTimeoutMillis = 1000,
-            idleTimeoutMillis = 2000,
-            keepAliveTime = 3000,
-            maxLifetime = 4000,
-            minimumIdle = 1,
-            maximumPoolSize = 10,
             targetServerType = targetServerType
         )
 
         val result = buildPostgresDataSource(config)
 
-        result.jdbcUrl shouldBe "jdbc:postgresql://host:1234/dbName"
-        result.connectionTimeout shouldBe 1000
-        result.idleTimeout shouldBe 2000
-        result.keepaliveTime shouldBe 3000
-        result.maxLifetime shouldBe 4000
-        result.minimumIdle shouldBe 1
-        result.maximumPoolSize shouldBe 10
-        result.dataSourceProperties["reWriteBatchedInserts"] shouldBe "true"
+        result.dataSourceProperties["targetServerType"] shouldBe targetServerType.jdbcParameterValue
 
-        result.dataSourceProperties.keys shouldNotContain "ssl"
-        result.dataSourceProperties.keys shouldNotContain "sslfactory"
-        result.dataSourceProperties.keys shouldNotContain "sslmode"
-
-        result.username shouldBe "user"
-        result.password shouldBe "password"
     }
 
 }


### PR DESCRIPTION
This PR adds support for configuring the TargetServerType property. TargetServerType is required to support connection failover documented [here](https://jdbc.postgresql.org/documentation/use/#connection-fail-over)